### PR TITLE
Propagate events up from shoe to shoe-bin

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -5,7 +5,18 @@ module.exports = function (stream) {
     var encoder = encode();
     var decoder = decode();
     encoder.pipe(stream).pipe(decoder);
-    return duplexer(encoder, decoder);
+        
+    var result = duplexer(encoder, decoder);
+
+    // propagate events up from shoe to shoe-bin
+    stream.on('close', function () {
+        result.emit('close');
+    });
+    stream.on('error', function (error) {
+        result.emit('error', error);
+    });
+
+    return result;
 };
 
 function encode () {


### PR DESCRIPTION
This is necessary to know when a browser session closes. This is the only indication that the disconnection occurs. `shoe` emits a `close` event but `shoe-bin` does not, so the event must be bubbled up. Added `error` event for good measure.